### PR TITLE
Add WikiPedia links for all Oceans

### DIFF
--- a/earth.js
+++ b/earth.js
@@ -10,19 +10,24 @@ const theEarthObjectJS = {
   },
   oceans: {
     arctic: {
-      description: ""
+      description: "",
+      wikipedia_link: "https://wikipedia.org/wiki/Arctic_Ocean"
     },
-    atlatic: {
-      description: ""
+    atlantic: {
+      description: "",
+      wikipedia_link: "https://wikipedia.org/wiki/Atlantic_Ocean"
     },
     pacific: {
-      description: ""
+      description: "",
+      wikipedia_link: "https://wikipedia.org/wiki/Pacific_Ocean"
     },
     indian: {
-      description: ""
+      description: "",
+      wikipedia_link: "https://wikipedia.org/wiki/Indian_Ocean"
     },
     southern: {
-      description: ""
+      description: "",
+      wikipedia_link: "https://wikipedia.org/wiki/Southern_Ocean"
     }
   }
 }


### PR DESCRIPTION
This resolves issue #1. Removed the "en" part of the wikipedia link as it would force wikipedia pages to open in English, which is not ideal.
Please add the `hacktoberfest-accepted` label if you're happy with the PR.